### PR TITLE
Changes made to compile on Debian unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ How this fork differs: the focus is on using limbo as a programming language on 
 
 To build the repo, install the package dependencies on Linux
 ```
-$ apt install libx11-dev libxext-dev linux-libc-dev
+$ apt install libx11-dev libxext-dev linux-libc-dev libpulse-dev
 ```
 
 Then in the root folder of the repo,

--- a/emu/port/devssl.c
+++ b/emu/port/devssl.c
@@ -8,6 +8,8 @@
 #include	"mp.h"
 #include	"libsec.h"
 
+extern int nrand(int n);
+
 typedef struct OneWay OneWay;
 struct OneWay
 {
@@ -49,7 +51,7 @@ struct Dstate
 	ushort	blocklen;	/* blocking length */
 
 	ushort	diglen;		/* length of digest */
-	DigestState *(*hf)(uchar*, u32, uchar*, DigestState*);	/* hash func */
+	DigestState *(*hf)(uchar*, ulong, uchar*, DigestState*);	/* hash func */
 
 	/* for SSL format */
 	int	max;			/* maximum unpadded data per msg */
@@ -854,7 +856,7 @@ struct Hashalg
 {
 	char	*name;
 	int	diglen;
-	DigestState *(*hf)(uchar*, u32, uchar*, DigestState*);
+	DigestState *(*hf)(uchar*, ulong, uchar*, DigestState*);
 };
 
 Hashalg hashtab[] =

--- a/lib9/create.c
+++ b/lib9/create.c
@@ -1,5 +1,6 @@
 #include "lib9.h"
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <fcntl.h>
 
 int

--- a/libinterp/ipint.h
+++ b/libinterp/ipint.h
@@ -11,3 +11,8 @@ void	ipintsmodinit(void);
 void	ipinttostr(void *ip, int base, char *buf, int buflen);
 
 extern	Type*	TIPint;
+extern	void	mpand(mpint *b1, mpint *b2, mpint *sum);
+extern	void	mpor(mpint *b1, mpint *b2, mpint *sum);
+extern	void	mpnot(mpint *b, mpint *r);
+extern	void	mpxor(mpint *b1, mpint *b2, mpint *sum);
+

--- a/libmath/FPcontrol-Linux.c
+++ b/libmath/FPcontrol-Linux.c
@@ -9,11 +9,13 @@ FPinit(void)
 	setfcr(FPPDBL|FPRNR|FPINVAL|FPZDIV|FPUNFL|FPOVFL);
 }
 
+void
 FPsave(void* envp)
 {
 	fegetenv((fenv_t*) envp);
 }
 
+void
 FPrestore(void* envp)
 {
 	fesetenv((fenv_t*) envp);

--- a/libtk/utils.c
+++ b/libtk/utils.c
@@ -1598,7 +1598,7 @@ tkdirty(Tk *tk)
 }
 
 static int
-qcmdcmp(const void *a, const void *b)
+qcmdcmp(void *a, void *b)
 {
 	return strcmp(((TkCmdtab*)a)->name, ((TkCmdtab*)b)->name);
 }

--- a/limbo/limbo.y
+++ b/limbo/limbo.y
@@ -1,5 +1,6 @@
 %{
 #include "limbo.h"
+#include <ctype.h>
 %}
 
 %union

--- a/mkfile
+++ b/mkfile
@@ -34,7 +34,7 @@ DIRS=\
 	appl\
 
 foo:QV:
-	echo mk all, clean, install, installall or nuke
+	echo mk all, clean, install, installall, nuke, or mkdirs
 
 all:V:		all-$HOSTMODEL
 clean:V:	clean-$HOSTMODEL

--- a/mkfiles/mkfile-Linux-amd64
+++ b/mkfiles/mkfile-Linux-amd64
@@ -21,6 +21,7 @@ CFLAGS=		-g\
 		-I$ROOT/include\
 		-DLINUX_AMD64\
 		-DSQLITE_OS_INFERNO\
+		-D_GNU_SOURCE\
 
 ANSICPP=
 LD=		cc


### PR DESCRIPTION
## Files needed to be modified, and reasons
### `lib9/create.c`

Added `#include <sys/stat.h>` to fix compiler error about implicit declaration of `mkdir()`

### `libmath/FPcontrol-Linux.c`

Added explicit `void` types to `FPsave()` and `FPrestore()` to fix compiler complaints.

### `limbo/limbo.y`

Needed to explicitly declare `#include <ctype.h>` to fix compiler error.
```
limbo.y:1938:30: error: implicit declaration of function ‘tolower’ [-Wimplicit-function-declaration]
```

### `libinterp/ipint.h`

Explicitly declared `mpand`, `mpor`, `mpnot`, and `mpxor`

### `libtk/utils.c`

removed `const` from declaration of `qcmdcmp()` to fix compiler error:
```
utils.c: In function ‘tksorttable’:
utils.c:1622:58: error: passing argument 4 of ‘infqsort’ from incompatible pointer type [-Wincompatible-pointer-types]
 1622 |                 qsort(c->cmd, c->ncmd, sizeof(TkCmdtab), qcmdcmp);
      |                                                          ^~~~~~~
      |                                                          |
      |                                                          int (*)(const void *, const void *)
In file included from utils.c:1:
/home/andrew/Documents/Projects/repos/inferno64/Linux/amd64/include/lib9.h:314:42: note: expected ‘int (*)(void *, void *)’ but argument is of type ‘int (*)(const void *, const void *)’
  314 | extern  void    qsort(void*, long, long, int (*)(void*, void*));
      |                                          ^~~~~~~~~~~~~~~~~~~~~
utils.c:1601:1: note: ‘qcmdcmp’ declared here
 1601 | qcmdcmp(const void *a, const void *b)
      | ^~~~~~~
utils.c: In function ‘tkrepeat’:
utils.c:2012:61: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
 2012 |                 autorpt = rptproc("autorepeat", TkRptclick, (void*)rptid, rptactive, ckrpt, dorpt);
      |                                                             ^
utils.c:2014:27: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
 2014 |                 rptwakeup((void*)rptid, autorpt);
      |                           ^
```

### `emu/port/devssl.c`

Added explicit `extern int nrand(int n);` to fix compiler error.
Changed Hashalg definition, `u32` becomes `ulong`
Changed DigestState definition from `u32` to `ulong`

# Directories needed to be created

```sh
mkdir -p Linux/amd64/{bin,lib}
mkdir -p acme/dis
mkdir -p dis/lib/{print,spki,strokes,styxconv,w3c,ftree,mash,convcs,crypt,encoding,ida}
mkdir -p dis/{spki,math,tiny}
mkdir -p dis/grid/demo
mkdir -p dis/{acme,charon,auxi,avr,disk,fs,games,lego,mpc,ndb,sh,usb,zip,mpeg}
mkdir -p dis/auth/proto
mkdir -p dis/ip/ppp
mkdir -p dis/wm/brutus
mkdir -p dis/svc/{httpd,webget}
```

# Missing packages
This package was missing from the documentation.
```sh
sudo apt install libpulse-dev
```

Fixes #7 